### PR TITLE
[cavert-pkirch] chapter iteration

### DIFF
--- a/cavert-pkirch/iteration/repeat.go
+++ b/cavert-pkirch/iteration/repeat.go
@@ -1,0 +1,5 @@
+package iteration
+
+func Repeat(char string) string {
+	return ""
+}

--- a/cavert-pkirch/iteration/repeat.go
+++ b/cavert-pkirch/iteration/repeat.go
@@ -1,5 +1,11 @@
 package iteration
 
 func Repeat(char string) string {
-	return ""
+	var repeated string
+
+	for i := 0; i < 5; i++ {
+		repeated += char
+	}
+
+	return repeated
 }

--- a/cavert-pkirch/iteration/repeat.go
+++ b/cavert-pkirch/iteration/repeat.go
@@ -1,5 +1,6 @@
 package iteration
 
+// Returns a string with the given string repeated by the given number.
 func Repeat(char string, iterations int) string {
 	var repeated string
 

--- a/cavert-pkirch/iteration/repeat.go
+++ b/cavert-pkirch/iteration/repeat.go
@@ -1,9 +1,9 @@
 package iteration
 
-func Repeat(char string) string {
+func Repeat(char string, iterations int) string {
 	var repeated string
 
-	for i := 0; i < 5; i++ {
+	for i := 0; i < iterations; i++ {
 		repeated += char
 	}
 

--- a/cavert-pkirch/iteration/repeat_test.go
+++ b/cavert-pkirch/iteration/repeat_test.go
@@ -10,3 +10,9 @@ func TestRepeat(t *testing.T) {
 		t.Errorf("expected %q but got %q", expected, repeated)
 	}
 }
+
+func BenchmarkRepeat(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Repeat("a")
+	}
+}

--- a/cavert-pkirch/iteration/repeat_test.go
+++ b/cavert-pkirch/iteration/repeat_test.go
@@ -1,0 +1,12 @@
+package iteration
+
+import "testing"
+
+func TestRepeat(t *testing.T) {
+	repeated := Repeat("a")
+	expected := "aaaaa"
+
+	if repeated != expected {
+		t.Errorf("expected %q but got %q", expected, repeated)
+	}
+}

--- a/cavert-pkirch/iteration/repeat_test.go
+++ b/cavert-pkirch/iteration/repeat_test.go
@@ -1,6 +1,9 @@
 package iteration
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestRepeat(t *testing.T) {
 	repeated := Repeat("a", 5)
@@ -24,5 +27,10 @@ func BenchmarkRepeat(b *testing.B) {
 			Repeat("a", 5000)
 		}
 	})
+}
 
+func ExampleRepeat() {
+	result := Repeat("a", 5)
+	fmt.Println(result)
+	// Output: aaaaa
 }

--- a/cavert-pkirch/iteration/repeat_test.go
+++ b/cavert-pkirch/iteration/repeat_test.go
@@ -3,7 +3,7 @@ package iteration
 import "testing"
 
 func TestRepeat(t *testing.T) {
-	repeated := Repeat("a")
+	repeated := Repeat("a", 5)
 	expected := "aaaaa"
 
 	if repeated != expected {
@@ -12,7 +12,17 @@ func TestRepeat(t *testing.T) {
 }
 
 func BenchmarkRepeat(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		Repeat("a")
-	}
+
+	b.Run("repeat 5 times", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			Repeat("a", 5)
+		}
+	})
+
+	b.Run("repeat 5000 times", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			Repeat("a", 5000)
+		}
+	})
+
 }

--- a/cavert-pkirch/iteration/repeat_test.go
+++ b/cavert-pkirch/iteration/repeat_test.go
@@ -2,6 +2,7 @@ package iteration
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -15,7 +16,6 @@ func TestRepeat(t *testing.T) {
 }
 
 func BenchmarkRepeat(b *testing.B) {
-
 	b.Run("repeat 5 times", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			Repeat("a", 5)
@@ -25,6 +25,20 @@ func BenchmarkRepeat(b *testing.B) {
 	b.Run("repeat 5000 times", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			Repeat("a", 5000)
+		}
+	})
+}
+
+func BenchmarkLibraryRepeat(b *testing.B) {
+	b.Run("repeat 5 times", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			strings.Repeat("a", 5)
+		}
+	})
+
+	b.Run("repeat 5000 times", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			strings.Repeat("a", 5000)
 		}
 	})
 }


### PR DESCRIPTION
Completed chapter Iteration. resolve #12 

In case you're interested how much faster the standard library is:

> vscode@f093418f88a7:/workspaces/golang-learning/cavert-pkirch/iteration$ go test -bench=.
> goos: linux
> goarch: amd64
> pkg: github.com/The-V8/golang-learning/cavert-pkirch/iteration
> BenchmarkRepeat/repeat_5_times-2                 9637508               **119 ns/op**
> BenchmarkRepeat/repeat_5000_times-2                  504           2369164 ns/op
> BenchmarkLibraryRepeat/repeat_5_times-2         26241955                **40.9 ns/op**
> BenchmarkLibraryRepeat/repeat_5000_times-2               1402546               900 ns/op